### PR TITLE
Use Streams for task list conversion

### DIFF
--- a/src/main/java/chillguy/task/TaskList.java
+++ b/src/main/java/chillguy/task/TaskList.java
@@ -83,9 +83,8 @@ public class TaskList {
      * @return An array of strings, where each string represents a task in the list.
      */
     public String[] getStringTaskList() {
-        List<String> list = new ArrayList<>();
-        this.taskList.forEach((taskNum, task) ->
-                list.add(" " + taskNum + ". " + task));
-        return list.toArray(new String[0]);
+        return this.taskList.entrySet().stream()
+                .map(entry -> " " + entry.getKey() + ". " + entry.getValue())
+                .toArray(String[]::new);
     }
 }


### PR DESCRIPTION
The getStringTaskList() method previously used a manual iteration over the taskList map, adding formatted task strings to an ArrayList, and then converting it to an array.

This approach can be simplified and made more efficient using the Streams API, which provides a cleaner and more declarative way to perform the transformation.

Let's refactor the method to use the Stream API for processing the taskList map.

This change improves code readability, reduces verbosity, and leverages Java's functional programming features to make the code more concise and maintainable.